### PR TITLE
Introducing Reusable Containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,6 +935,24 @@ def test_container_wrapper_class(apiserver):
 
 ```
 
+## Reusable Containers
+
+By default the container fixture factory of Pytest-Docker-Tools will create every defined container when pytest is invoked. At the end a finalizer will remove the container to clean things up.
+This behavior might not always be what you want.
+As an example you may be writing a test and want to execute it repeatedly. Normally this will always take a couple of extra  
+seconds to spawn the containers, which you might find annoying. Also, you may tend to hit the stop button more than once if one of your tests fails which will abort the normal container cleanup by the finalizers.   
+
+By using the `--reuse_containers` command line argument containers will not be cleaned up after executing the tests. By using the name property the container fixture factory of Pytest-Docker-Tools 
+will try to find a container with that name and return it to your test instead of creating a new test.
+
+### Notes on using reusable Containers
+
++ Containers created using the `--reuse_containers` option will not have a finalizer, so scopes will may not behave like they normally would
++ When reusing containers you are responsible to clean up databases as your test data will not be deleted when your tests are finished.
++ Each Container created by Pytest-Docker-Tools will get the following label: `Container_Creator: Pytest-Docker-Tools`. When required, this can be used to search for left over 
+  containers for manual clean up by `docker ps -a --filter "label=Container_Creator=Pytest-Docker-Tools" | xargs docker rm -f`
+
+
 ## Hacking
 
 Set up a virtualenv for development:

--- a/README.md
+++ b/README.md
@@ -942,16 +942,16 @@ This behavior might not always be what you want.
 As an example you may be writing a test and want to execute it repeatedly. Normally this will always take a couple of extra  
 seconds to spawn the containers, which you might find annoying. Also, you may tend to hit the stop button more than once if one of your tests fails which will abort the normal container cleanup by the finalizers.   
 
-By using the `--reuse_containers` command line argument and specifying the `name` attribute containers will not be cleaned up after executing the tests. By using the name property the container fixture factory of Pytest-Docker-Tools 
+By using the `--reuse-containers` command line argument and specifying the `name` attribute containers will not be cleaned up after executing the tests. By using the name property the container fixture factory of Pytest-Docker-Tools 
 will try to find a container with that name and return it to your test instead of creating a new test.  
 **Attention**: Not using the `name` attribute results in creating multiple containers as usual, but without the clean up finalizer. 
 
 ### Notes on using reusable Containers
 
-+ Containers created using the `--reuse_containers` option will not have a finalizer, so scopes will may not behave like they normally would
++ Containers created using the `--reuse-containers` option will not have a finalizer, so scopes will may not behave like they normally would
 + When reusing containers you are responsible to clean up databases as your test data will not be deleted when your tests are finished.
-+ Each Container created by Pytest-Docker-Tools will get the following label: `Container_Creator: Pytest-Docker-Tools`. When required, this can be used to search for left over 
-  containers for manual clean up by `docker ps -aq --filter "label=Container_Creator=Pytest-Docker-Tools" | xargs docker rm -f`
++ Each Container created by Pytest-Docker-Tools will get the following label: `container-creator: pytest-docker-tools`. When required, this can be used to search for left over 
+  containers for manual clean up by `docker ps -aq --filter "label=container-creator=pytest-docker-tools" | xargs docker rm -f`
 
 
 ## Hacking

--- a/README.md
+++ b/README.md
@@ -946,7 +946,7 @@ By using the `--reuse-containers` command line argument and specifying the `name
 will try to find a container with that name and return it to your test instead of creating a new test.  
 **Attention**: Not using the `name` attribute results in creating multiple containers as usual, but without the clean up finalizer. 
 
-### Notes on using reusable Containers
+### Notes on using Reusable Containers
 
 + Containers created using the `--reuse-containers` option will not have a finalizer, so scopes will may not behave like they normally would
 + When reusing containers you are responsible to clean up databases as your test data will not be deleted when your tests are finished.

--- a/README.md
+++ b/README.md
@@ -950,7 +950,7 @@ will try to find a container with that name and return it to your test instead o
 + Containers created using the `--reuse_containers` option will not have a finalizer, so scopes will may not behave like they normally would
 + When reusing containers you are responsible to clean up databases as your test data will not be deleted when your tests are finished.
 + Each Container created by Pytest-Docker-Tools will get the following label: `Container_Creator: Pytest-Docker-Tools`. When required, this can be used to search for left over 
-  containers for manual clean up by `docker ps -a --filter "label=Container_Creator=Pytest-Docker-Tools" | xargs docker rm -f`
+  containers for manual clean up by `docker ps -aq --filter "label=Container_Creator=Pytest-Docker-Tools" | xargs docker rm -f`
 
 
 ## Hacking

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ You have written a software application (in any language) and have packaged in a
 
  * want to reason about your environment in a similar way to a `docker-compose.yml`
  * want the environment to be automatically created and destroyed as tests run
+ * want the option to reuse previously created containers when executing tests in high frequency 
  * don't want to have to write loads of boilerplate code for creating the test environment
  * want to be able to run the tests in parallel
  * want the tests to be reliable

--- a/README.md
+++ b/README.md
@@ -942,8 +942,9 @@ This behavior might not always be what you want.
 As an example you may be writing a test and want to execute it repeatedly. Normally this will always take a couple of extra  
 seconds to spawn the containers, which you might find annoying. Also, you may tend to hit the stop button more than once if one of your tests fails which will abort the normal container cleanup by the finalizers.   
 
-By using the `--reuse_containers` command line argument containers will not be cleaned up after executing the tests. By using the name property the container fixture factory of Pytest-Docker-Tools 
-will try to find a container with that name and return it to your test instead of creating a new test.
+By using the `--reuse_containers` command line argument and specifying the `name` attribute containers will not be cleaned up after executing the tests. By using the name property the container fixture factory of Pytest-Docker-Tools 
+will try to find a container with that name and return it to your test instead of creating a new test.  
+**Attention**: Not using the `name` attribute results in creating multiple containers as usual, but without the clean up finalizer. 
 
 ### Notes on using reusable Containers
 

--- a/pytest_docker_tools/factories/container.py
+++ b/pytest_docker_tools/factories/container.py
@@ -11,8 +11,8 @@ def container(request, docker_client, wrapper_class, **kwargs):
     wrapper_class = wrapper_class or Container
 
     if request.config.option.reuse_containers:
-        name = kwargs['name']
-        if name:
+        if 'name' in kwargs.keys():
+            name = kwargs['name']
             current_containers = docker_client.containers.list(ignore_removed=True)
             for cont in current_containers:
                 if cont.name == name:

--- a/pytest_docker_tools/factories/container.py
+++ b/pytest_docker_tools/factories/container.py
@@ -8,16 +8,30 @@ from pytest_docker_tools.wrappers import Container
 def container(request, docker_client, wrapper_class, **kwargs):
     """ Docker container: image={image} """
 
+    wrapper_class = wrapper_class or Container
+
+    if request.config.option.reuse_containers:
+        name = kwargs['name']
+        if name:
+            current_containers = docker_client.containers.list()
+            for cont in current_containers:
+                if cont.name == name:
+                    raw_container = cont
+                    return wrapper_class(raw_container)
+        else:
+            raise RuntimeError("Error: Tried to use '--reuse_containers' command line argument without "
+                               "setting 'name' attribute on container")
+
     timeout = kwargs.pop("timeout", 30)
 
     kwargs.update({"detach": True})
 
     raw_container = docker_client.containers.run(**kwargs)
-    request.addfinalizer(
-        lambda: raw_container.remove(force=True) and raw_container.wait(timeout=10)
-    )
+    if not request.config.option.reuse_containers:
+        request.addfinalizer(
+            lambda: raw_container.remove(force=True) and raw_container.wait(timeout=10)
+        )
 
-    wrapper_class = wrapper_class or Container
     container = wrapper_class(raw_container)
 
     try:

--- a/pytest_docker_tools/factories/container.py
+++ b/pytest_docker_tools/factories/container.py
@@ -11,23 +11,39 @@ def container(request, docker_client, wrapper_class, **kwargs):
     wrapper_class = wrapper_class or Container
 
     if request.config.option.reuse_containers:
-        if 'name' in kwargs.keys():
-            name = kwargs['name']
+        if "name" in kwargs.keys():
+            name = kwargs["name"]
             current_containers = docker_client.containers.list(ignore_removed=True)
             for cont in current_containers:
                 if cont.name == name:
-                    if 'Pytest-Docker-Tools.Reusable_Container' in cont.attrs['Config']['Labels'] and \
-                            cont.attrs['Config']['Labels']['Pytest-Docker-Tools.Reusable_Container'] == "True":
+                    if (
+                        "Pytest-Docker-Tools.Reusable_Container"
+                        in cont.attrs["Config"]["Labels"]
+                        and cont.attrs["Config"]["Labels"][
+                            "Pytest-Docker-Tools.Reusable_Container"
+                        ]
+                        == "True"
+                    ):
                         return wrapper_class(cont)
         else:
-            raise RuntimeError("Error: Tried to use '--reuse_containers' command line argument without "
-                               "setting 'name' attribute on container")
+            raise RuntimeError(
+                "Error: Tried to use '--reuse_containers' command line argument without "
+                "setting 'name' attribute on container"
+            )
 
     timeout = kwargs.pop("timeout", 30)
 
     kwargs.update({"detach": True})
-    kwargs.update({'labels': {'Container_Creator': 'Pytest-Docker-Tools',
-                              'Pytest-Docker-Tools.Reusable_Container': str(request.config.option.reuse_containers)}})
+    kwargs.update(
+        {
+            "labels": {
+                "Container_Creator": "Pytest-Docker-Tools",
+                "Pytest-Docker-Tools.Reusable_Container": str(
+                    request.config.option.reuse_containers
+                ),
+            }
+        }
+    )
 
     raw_container = docker_client.containers.run(**kwargs)
     if not request.config.option.reuse_containers:

--- a/pytest_docker_tools/factories/container.py
+++ b/pytest_docker_tools/factories/container.py
@@ -36,9 +36,7 @@ def container(request, docker_client, wrapper_class, **kwargs):
         {
             "labels": {
                 "container-creator": "pytest-docker-tools",
-                LABEL_REUSABLE_CONTAINER: str(
-                    request.config.option.reuse_containers
-                ),
+                LABEL_REUSABLE_CONTAINER: str(request.config.option.reuse_containers),
             }
         }
     )

--- a/pytest_docker_tools/factories/container.py
+++ b/pytest_docker_tools/factories/container.py
@@ -2,7 +2,11 @@ from pytest import UsageError
 
 from pytest_docker_tools.builder import fixture_factory
 from pytest_docker_tools.exceptions import ContainerNotReady, TimeoutError
-from pytest_docker_tools.utils import wait_for_callable, is_reusable_container, DOCKER_LABEL_REUSABLE_CONTAINER
+from pytest_docker_tools.utils import (
+    DOCKER_LABEL_REUSABLE_CONTAINER,
+    is_reusable_container,
+    wait_for_callable,
+)
 from pytest_docker_tools.wrappers import Container
 
 

--- a/pytest_docker_tools/factories/container.py
+++ b/pytest_docker_tools/factories/container.py
@@ -3,7 +3,7 @@ from pytest import UsageError
 from pytest_docker_tools.builder import fixture_factory
 from pytest_docker_tools.exceptions import ContainerNotReady, TimeoutError
 from pytest_docker_tools.utils import (
-    DOCKER_LABEL_REUSABLE_CONTAINER,
+    LABEL_REUSABLE_CONTAINER,
     is_reusable_container,
     wait_for_callable,
 )
@@ -36,7 +36,7 @@ def container(request, docker_client, wrapper_class, **kwargs):
         {
             "labels": {
                 "container-creator": "pytest-docker-tools",
-                DOCKER_LABEL_REUSABLE_CONTAINER: str(
+                LABEL_REUSABLE_CONTAINER: str(
                     request.config.option.reuse_containers
                 ),
             }

--- a/pytest_docker_tools/plugin.py
+++ b/pytest_docker_tools/plugin.py
@@ -49,7 +49,6 @@ def pytest_addoption(parser):
     group.addoption(
         "--reuse_containers",
         action="store_true",
-        # help="shortcut for '--dist=load --tx=NUM*popen', "
-        # "you can use 'auto' here for auto detection CPUs number on "
-        # "host system and it will be 0 when used with --pdb",
+        help="reuse existing containers instead of always creating new ones. Requires the 'name' attribute to be set"
+             "on container definition"
     )

--- a/pytest_docker_tools/plugin.py
+++ b/pytest_docker_tools/plugin.py
@@ -50,5 +50,5 @@ def pytest_addoption(parser):
         "--reuse_containers",
         action="store_true",
         help="reuse existing containers instead of always creating new ones. Requires the 'name' attribute to be set"
-             "on container definition"
+        "on container definition",
     )

--- a/pytest_docker_tools/plugin.py
+++ b/pytest_docker_tools/plugin.py
@@ -47,8 +47,9 @@ def pytest_runtest_makereport(item, call):
 def pytest_addoption(parser):
     group = parser.getgroup("pytest-docker-tools", "Pytest Docker Tools")
     group.addoption(
-        "--reuse_containers",
+        "--reuse-containers",
         action="store_true",
+        dest="reuse_containers",
         help="reuse existing containers instead of always creating new ones. Requires the 'name' attribute to be set"
         "on container definition",
     )

--- a/pytest_docker_tools/plugin.py
+++ b/pytest_docker_tools/plugin.py
@@ -42,3 +42,14 @@ def pytest_runtest_makereport(item, call):
                     fixture.logs(),
                 )
             )
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("pytest-docker-tools", "Pytest Docker Tools")
+    group.addoption(
+        "--reuse_containers",
+        action="store_true",
+        # help="shortcut for '--dist=load --tx=NUM*popen', "
+        # "you can use 'auto' here for auto detection CPUs number on "
+        # "host system and it will be 0 when used with --pdb",
+    )

--- a/pytest_docker_tools/utils.py
+++ b/pytest_docker_tools/utils.py
@@ -36,8 +36,6 @@ def tests_inside_container():
 def is_reusable_container(container):
     return (
         DOCKER_LABEL_REUSABLE_CONTAINER in container.attrs["Config"]["Labels"]
-        and container.attrs["Config"]["Labels"][
-            DOCKER_LABEL_REUSABLE_CONTAINER
-        ]
+        and container.attrs["Config"]["Labels"][DOCKER_LABEL_REUSABLE_CONTAINER]
         == "True"
     )

--- a/pytest_docker_tools/utils.py
+++ b/pytest_docker_tools/utils.py
@@ -4,7 +4,7 @@ import time
 
 from .exceptions import TimeoutError
 
-DOCKER_LABEL_REUSABLE_CONTAINER = "pytest-docker-tools.reusable-container"
+LABEL_REUSABLE_CONTAINER = "pytest-docker-tools.reusable-container"
 
 
 def wait_for_callable(message, callable, timeout=30):
@@ -34,4 +34,4 @@ def tests_inside_container():
 
 
 def is_reusable_container(container):
-    return container.attrs["Config"]["Labels"].get(DOCKER_LABEL_REUSABLE_CONTAINER) == "True"
+    return container.attrs["Config"]["Labels"].get(LABEL_REUSABLE_CONTAINER) == "True"

--- a/pytest_docker_tools/utils.py
+++ b/pytest_docker_tools/utils.py
@@ -4,7 +4,6 @@ import time
 
 from .exceptions import TimeoutError
 
-
 DOCKER_LABEL_REUSABLE_CONTAINER = "pytest-docker-tools.reusable-container"
 
 

--- a/pytest_docker_tools/utils.py
+++ b/pytest_docker_tools/utils.py
@@ -34,8 +34,4 @@ def tests_inside_container():
 
 
 def is_reusable_container(container):
-    return (
-        DOCKER_LABEL_REUSABLE_CONTAINER in container.attrs["Config"]["Labels"]
-        and container.attrs["Config"]["Labels"][DOCKER_LABEL_REUSABLE_CONTAINER]
-        == "True"
-    )
+    return container.attrs["Config"]["Labels"].get(DOCKER_LABEL_REUSABLE_CONTAINER) == "True"

--- a/pytest_docker_tools/utils.py
+++ b/pytest_docker_tools/utils.py
@@ -5,6 +5,9 @@ import time
 from .exceptions import TimeoutError
 
 
+DOCKER_LABEL_REUSABLE_CONTAINER = "pytest-docker-tools.reusable-container"
+
+
 def wait_for_callable(message, callable, timeout=30):
     """
     Runs a callable once a second until it returns True or we hit the timeout.
@@ -29,3 +32,13 @@ def tests_inside_container():
     """ Returns True if tests are running inside a Linux container """
 
     return os.path.isfile("/.dockerenv") or os.path.isfile("/run/.containerenv")
+
+
+def is_reusable_container(container):
+    return (
+        DOCKER_LABEL_REUSABLE_CONTAINER in container.attrs["Config"]["Labels"]
+        and container.attrs["Config"]["Labels"][
+            DOCKER_LABEL_REUSABLE_CONTAINER
+        ]
+        == "True"
+    )

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -4,7 +4,7 @@ import socket
 import pytest
 
 from pytest_docker_tools import build, container, fetch, image
-from pytest_docker_tools.utils import wait_for_callable
+from pytest_docker_tools.utils import wait_for_callable, DOCKER_LABEL_REUSABLE_CONTAINER
 
 test_container_1_image = fetch(repository="redis:latest")
 test_container_1_same_image = image(name="redis:latest")
@@ -63,12 +63,12 @@ def test_container_ipv6(ipv6):
 
 def test_container_label(docker_client, test_container_1):
     for c in docker_client.containers.list(ignore_removed=True):
-        assert "Container_Creator" in c.attrs["Config"]["Labels"].keys()
+        assert "container-creator" in c.attrs["Config"]["Labels"].keys()
         assert (
-            "Pytest-Docker-Tools.Reusable_Container"
+            DOCKER_LABEL_REUSABLE_CONTAINER
             in c.attrs["Config"]["Labels"].keys()
         )
-        assert c.attrs["Config"]["Labels"]["Container_Creator"] == "Pytest-Docker-Tools"
+        assert c.attrs["Config"]["Labels"]["container-creator"] == "pytest-docker-tools"
 
         break
     else:

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -4,7 +4,7 @@ import socket
 import pytest
 
 from pytest_docker_tools import build, container, fetch, image
-from pytest_docker_tools.utils import DOCKER_LABEL_REUSABLE_CONTAINER, wait_for_callable
+from pytest_docker_tools.utils import LABEL_REUSABLE_CONTAINER, wait_for_callable
 
 test_container_1_image = fetch(repository="redis:latest")
 test_container_1_same_image = image(name="redis:latest")
@@ -64,7 +64,7 @@ def test_container_ipv6(ipv6):
 def test_container_label(docker_client, test_container_1):
     for c in docker_client.containers.list(ignore_removed=True):
         assert "container-creator" in c.attrs["Config"]["Labels"].keys()
-        assert DOCKER_LABEL_REUSABLE_CONTAINER in c.attrs["Config"]["Labels"].keys()
+        assert LABEL_REUSABLE_CONTAINER in c.attrs["Config"]["Labels"].keys()
         assert c.attrs["Config"]["Labels"]["container-creator"] == "pytest-docker-tools"
 
         break

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -64,10 +64,7 @@ def test_container_ipv6(ipv6):
 def test_container_label(docker_client, test_container_1):
     for c in docker_client.containers.list(ignore_removed=True):
         assert "container-creator" in c.attrs["Config"]["Labels"].keys()
-        assert (
-            DOCKER_LABEL_REUSABLE_CONTAINER
-            in c.attrs["Config"]["Labels"].keys()
-        )
+        assert DOCKER_LABEL_REUSABLE_CONTAINER in c.attrs["Config"]["Labels"].keys()
         assert c.attrs["Config"]["Labels"]["container-creator"] == "pytest-docker-tools"
 
         break

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -3,10 +3,11 @@ import socket
 
 import pytest
 
-from pytest_docker_tools import build, container, fetch
+from pytest_docker_tools import build, container, fetch, image
 from pytest_docker_tools.utils import wait_for_callable
 
 test_container_1_image = fetch(repository="redis:latest")
+test_container_1_same_image = image(name="redis:latest")
 
 test_container_1 = container(
     image="{test_container_1_image.id}",
@@ -16,7 +17,15 @@ test_container_1 = container(
     name="test_container",
 )
 
-reused_container = container(name="test_container")
+original_container_1 = container(
+    image="{test_container_1_same_image.id}",
+    ports={
+        "6379/tcp": None,
+    },
+    name="test_container_org",
+)
+
+reused_container = container(name="test_container_org")
 
 ipv6_folder = os.path.join(os.path.dirname(__file__), "fixtures/ipv6")
 ipv6_image = build(path=ipv6_folder)
@@ -67,9 +76,9 @@ def test_container_label(docker_client, test_container_1):
 
 
 def test_container_reuse_create(
-    enable_container_reuse, docker_client, test_container_1, reused_container
+    enable_container_reuse, docker_client, original_container_1, reused_container
 ):
-    assert test_container_1.id == reused_container.id
+    assert original_container_1.id == reused_container.id
     for c in docker_client.containers.list(ignore_removed=True):
-        if c.id == test_container_1.id:
+        if c.id == original_container_1.id:
             c.remove(force=True)

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -1,6 +1,8 @@
 import os
 import socket
 
+import pytest
+
 from pytest_docker_tools import build, container, fetch
 from pytest_docker_tools.utils import wait_for_callable
 
@@ -11,6 +13,11 @@ test_container_1 = container(
     ports={
         "6379/tcp": None,
     },
+    name="test_container"
+)
+
+reused_container = container(
+    name="test_container"
 )
 
 ipv6_folder = os.path.join(os.path.dirname(__file__), "fixtures/ipv6")
@@ -21,6 +28,13 @@ ipv6 = container(
         "1234/udp": None,
     },
 )
+
+
+@pytest.fixture()
+def enable_container_reuse(request):
+    request.config.option.reuse_containers = True
+    yield
+    request.config.option.reuse_containers = False
 
 
 def test_container_created(docker_client, test_container_1):
@@ -38,3 +52,21 @@ def test_container_ipv6(ipv6):
     sock.sendto(b"msg", addr)
 
     wait_for_callable("Waiting for delivery confirmation", lambda: "msg" in ipv6.logs())
+
+
+def test_container_label(docker_client, test_container_1):
+    for c in docker_client.containers.list(ignore_removed=True):
+        assert 'Container_Creator' in c.attrs['Config']['Labels'].keys()
+        assert 'Pytest-Docker-Tools.Reusable_Container' in c.attrs['Config']['Labels'].keys()
+        assert c.attrs['Config']['Labels']['Container_Creator'] == 'Pytest-Docker-Tools'
+
+        break
+    else:
+        assert False, "Looks like we failed to start a container"
+
+
+def test_container_reuse_create(enable_container_reuse, docker_client, test_container_1, reused_container):
+    assert test_container_1.id == reused_container.id
+    for c in docker_client.containers.list(ignore_removed=True):
+        if c.id == test_container_1.id:
+            c.remove(force=True)

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -13,12 +13,10 @@ test_container_1 = container(
     ports={
         "6379/tcp": None,
     },
-    name="test_container"
+    name="test_container",
 )
 
-reused_container = container(
-    name="test_container"
-)
+reused_container = container(name="test_container")
 
 ipv6_folder = os.path.join(os.path.dirname(__file__), "fixtures/ipv6")
 ipv6_image = build(path=ipv6_folder)
@@ -56,16 +54,21 @@ def test_container_ipv6(ipv6):
 
 def test_container_label(docker_client, test_container_1):
     for c in docker_client.containers.list(ignore_removed=True):
-        assert 'Container_Creator' in c.attrs['Config']['Labels'].keys()
-        assert 'Pytest-Docker-Tools.Reusable_Container' in c.attrs['Config']['Labels'].keys()
-        assert c.attrs['Config']['Labels']['Container_Creator'] == 'Pytest-Docker-Tools'
+        assert "Container_Creator" in c.attrs["Config"]["Labels"].keys()
+        assert (
+            "Pytest-Docker-Tools.Reusable_Container"
+            in c.attrs["Config"]["Labels"].keys()
+        )
+        assert c.attrs["Config"]["Labels"]["Container_Creator"] == "Pytest-Docker-Tools"
 
         break
     else:
         assert False, "Looks like we failed to start a container"
 
 
-def test_container_reuse_create(enable_container_reuse, docker_client, test_container_1, reused_container):
+def test_container_reuse_create(
+    enable_container_reuse, docker_client, test_container_1, reused_container
+):
     assert test_container_1.id == reused_container.id
     for c in docker_client.containers.list(ignore_removed=True):
         if c.id == test_container_1.id:

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -4,7 +4,7 @@ import socket
 import pytest
 
 from pytest_docker_tools import build, container, fetch, image
-from pytest_docker_tools.utils import wait_for_callable, DOCKER_LABEL_REUSABLE_CONTAINER
+from pytest_docker_tools.utils import DOCKER_LABEL_REUSABLE_CONTAINER, wait_for_callable
 
 test_container_1_image = fetch(repository="redis:latest")
 test_container_1_same_image = image(name="redis:latest")

--- a/tests/integration/test_orchestration.py
+++ b/tests/integration/test_orchestration.py
@@ -5,6 +5,7 @@ on another container, and so on, then all the contains should be built in the
 right order.
 """
 import os
+
 from pytest_docker_tools import build, container, fetch, network, volume
 
 redis_image = fetch(repository="redis:latest")

--- a/tests/integration/test_orchestration.py
+++ b/tests/integration/test_orchestration.py
@@ -4,7 +4,7 @@ If a container depends on an image and a container, and that container depends
 on another container, and so on, then all the contains should be built in the
 right order.
 """
-
+import os
 from pytest_docker_tools import build, container, fetch, network, volume
 
 redis_image = fetch(repository="redis:latest")
@@ -16,7 +16,7 @@ redis0 = container(
     },
 )
 
-foobar = build(path="tests/integration")
+foobar = build(path=os.getcwd())
 mynetwork = network()
 myvolume = volume()
 mycontainer = container(

--- a/tests/integration/test_orchestration.py
+++ b/tests/integration/test_orchestration.py
@@ -4,8 +4,6 @@ If a container depends on an image and a container, and that container depends
 on another container, and so on, then all the contains should be built in the
 right order.
 """
-import os
-
 from pytest_docker_tools import build, container, fetch, network, volume
 
 redis_image = fetch(repository="redis:latest")
@@ -17,7 +15,7 @@ redis0 = container(
     },
 )
 
-foobar = build(path=os.getcwd())
+foobar = build(path="tests/integration")
 mynetwork = network()
 myvolume = volume()
 mycontainer = container(

--- a/tests/integration/test_orchestration.py
+++ b/tests/integration/test_orchestration.py
@@ -4,6 +4,7 @@ If a container depends on an image and a container, and that container depends
 on another container, and so on, then all the contains should be built in the
 right order.
 """
+
 from pytest_docker_tools import build, container, fetch, network, volume
 
 redis_image = fetch(repository="redis:latest")


### PR DESCRIPTION
This PR introduces to reuse containers between several pytest invocations by setting the command line argument `--reuse_containers`. This is useful to save the extra seconds for container spawning when a developer may execute the same test over and over again.  
Documentation has been provided which also includes a warning that the developer is responsible for e.g. database clean up when reusing containers.