### PR TITLE
now evaluating --reuse-containers in network fixture factory

### DIFF
--- a/pytest_docker_tools/factories/network.py
+++ b/pytest_docker_tools/factories/network.py
@@ -11,7 +11,9 @@ def network(request, docker_client, wrapper_class, **kwargs):
 
     print(f"Creating network {name}")
     network = docker_client.networks.create(name, **kwargs)
-    request.addfinalizer(lambda: network.remove())
+
+    if not request.config.option.reuse_containers:
+        request.addfinalizer(lambda: network.remove())
 
     wrapper_class = wrapper_class or (lambda network: network)
     return wrapper_class(network)

--- a/pytest_docker_tools/factories/volume.py
+++ b/pytest_docker_tools/factories/volume.py
@@ -50,7 +50,9 @@ def volume(request, docker_client, wrapper_class, **kwargs):
 
     print(f"Creating volume {name}")
     volume = docker_client.volumes.create(name, **kwargs)
-    request.addfinalizer(lambda: volume.remove(True))
+
+    if not request.config.option.reuse_containers:
+        request.addfinalizer(lambda: volume.remove(True))
 
     if seeds:
         _populate_volume(docker_client, volume, seeds)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.fixture()
+def enable_container_reuse(request):
+    request.config.option.reuse_containers = True
+    yield
+    request.config.option.reuse_containers = False

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -1,8 +1,6 @@
 import os
 import socket
 
-import pytest
-
 from pytest_docker_tools import build, container, fetch, image
 from pytest_docker_tools.utils import LABEL_REUSABLE_CONTAINER, wait_for_callable
 

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -37,13 +37,6 @@ ipv6 = container(
 )
 
 
-@pytest.fixture()
-def enable_container_reuse(request):
-    request.config.option.reuse_containers = True
-    yield
-    request.config.option.reuse_containers = False
-
-
 def test_container_created(docker_client, test_container_1):
     for c in docker_client.containers.list(ignore_removed=True):
         if c.id == test_container_1.id:

--- a/tests/integration/test_network.py
+++ b/tests/integration/test_network.py
@@ -1,11 +1,21 @@
 from pytest_docker_tools import network
 
 test_network_1 = network()
+test_network_2 = network()
 
 
-def test_network_created(enable_container_reuse, docker_client, test_network_1):
+def test_network_1_created(docker_client, test_network_1):
     for n in docker_client.networks.list():
         if n.id == test_network_1.id:
+            # Looks like we managed to start one!
+            break
+    else:
+        assert False, "Looks like we failed to create a network"
+
+
+def test_reusable_network_2_created(enable_container_reuse, docker_client, test_network_2):
+    for n in docker_client.networks.list():
+        if n.id == test_network_2.id:
             # Looks like we managed to start one!
             break
     else:

--- a/tests/integration/test_network.py
+++ b/tests/integration/test_network.py
@@ -14,7 +14,7 @@ def test_network_1_created(docker_client, test_network_1):
 
 
 def test_reusable_network_2_created(
-        enable_container_reuse, docker_client, test_network_2
+    enable_container_reuse, docker_client, test_network_2
 ):
     for n in docker_client.networks.list():
         if n.id == test_network_2.id:

--- a/tests/integration/test_network.py
+++ b/tests/integration/test_network.py
@@ -14,8 +14,7 @@ def test_network_1_created(docker_client, test_network_1):
 
 
 def test_reusable_network_2_created(
-        enable_container_reuse, docker_client, test_network_2
-):
+        enable_container_reuse, docker_client, test_network_2):
     for n in docker_client.networks.list():
         if n.id == test_network_2.id:
             # Looks like we managed to start one!

--- a/tests/integration/test_network.py
+++ b/tests/integration/test_network.py
@@ -3,7 +3,7 @@ from pytest_docker_tools import network
 test_network_1 = network()
 
 
-def test_network_created(docker_client, test_network_1):
+def test_network_created(enable_container_reuse, docker_client, test_network_1):
     for n in docker_client.networks.list():
         if n.id == test_network_1.id:
             # Looks like we managed to start one!

--- a/tests/integration/test_network.py
+++ b/tests/integration/test_network.py
@@ -14,7 +14,8 @@ def test_network_1_created(docker_client, test_network_1):
 
 
 def test_reusable_network_2_created(
-        enable_container_reuse, docker_client, test_network_2):
+        enable_container_reuse, docker_client, test_network_2
+):
     for n in docker_client.networks.list():
         if n.id == test_network_2.id:
             # Looks like we managed to start one!

--- a/tests/integration/test_network.py
+++ b/tests/integration/test_network.py
@@ -13,7 +13,9 @@ def test_network_1_created(docker_client, test_network_1):
         assert False, "Looks like we failed to create a network"
 
 
-def test_reusable_network_2_created(enable_container_reuse, docker_client, test_network_2):
+def test_reusable_network_2_created(
+        enable_container_reuse, docker_client, test_network_2
+):
     for n in docker_client.networks.list():
         if n.id == test_network_2.id:
             # Looks like we managed to start one!

--- a/tests/integration/test_volume.py
+++ b/tests/integration/test_volume.py
@@ -1,11 +1,23 @@
 from pytest_docker_tools import volume
 
 test_volume_1 = volume()
+test_volume_2 = volume()
 
 
-def test_volume_created(docker_client, test_volume_1):
+def test_volume1_created(docker_client, test_volume_1):
     for v in docker_client.volumes.list():
         if v.id == test_volume_1.id:
+            # Looks like we managed to start one!
+            break
+    else:
+        assert False, "Looks like we failed to create a volume"
+
+
+def test_reusable_volume2_created(
+        enable_container_reuse, docker_client, test_volume_2
+):
+    for v in docker_client.volumes.list():
+        if v.id == test_volume_2.id:
             # Looks like we managed to start one!
             break
     else:

--- a/tests/integration/test_volume.py
+++ b/tests/integration/test_volume.py
@@ -13,9 +13,7 @@ def test_volume1_created(docker_client, test_volume_1):
         assert False, "Looks like we failed to create a volume"
 
 
-def test_reusable_volume2_created(
-        enable_container_reuse, docker_client, test_volume_2
-):
+def test_reusable_volume2_created(enable_container_reuse, docker_client, test_volume_2):
     for v in docker_client.volumes.list():
         if v.id == test_volume_2.id:
             # Looks like we managed to start one!


### PR DESCRIPTION
Unfortunately I didn't run into this issue earlier. When using reusable containers the finalizer for deleting the container is not registered. In this case the same has to be done to the created network. Otherwise it will try to delete the network which cannot succeed because there are active containers.

Sorry that I've overseen this.