### PR TITLE
Automatic replacement of stale containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ def test_session_3(memcache_session):
     sock = socket.socket()
     sock.connect(('127.0.0.1', memcache_session.ports['11211/tcp'][0]))
     sock.sendall(b'get mykey\r\n')
-    assert sock.recv(1024) == b'VALUE mykey 0 4\r\ndata\r\nEND\r\n'
+    assert sock.recv(1024).endswith(b'END\r\n')
     sock.close()
 
 def test_module_3(memcache_module):

--- a/README.md
+++ b/README.md
@@ -972,20 +972,17 @@ def test_container_wrapper_class(apiserver):
 
 ## Reusable Containers
 
-By default, the container fixture factory of Pytest-Docker-Tools will create every defined container when pytest is invoked. At the end a finalizer will remove the container to clean things up.
-This behavior might not always be what you want.
-As an example you may be writing a test and want to execute it repeatedly. Normally this will always take a couple of extra  
-seconds to spawn the containers, which you might find annoying. Also, you may tend to hit the stop button more than once if one of your tests fails which will abort the normal container cleanup by the finalizers.   
+By default, the container fixture factory of pytest-docker-tools will create every defined container when pytest is invoked, and clean them up before the session ends. This ensures that your test environment is clean and your tests aren't passing because of some tate left in the containers previously.
 
-By using the `--reuse-containers` command line argument in a first execution while specifying the `name` attribute on containers, volumes and networks prevent that they will be clean up after executing the tests.
-In a consecutive run of pytest using the same command line argument the fixture factories of Pytest-Docker-Tools will try to find the previously created resources by their given name and return them to your test instead of creating them.  
-**Attention**: When using `--reuse-containers` you must set the `name` attribute, or you will run into an `UsageException`. If you don't use `--reuse-containers` setting the `name attribute is not required. 
+Sometimes this behavior might not be what you want. When you are developing iteratively and running the tests over and over again the speed of your "test cycle" (how long it takes to fix a typo and re-run the tests) becomes important. When using the `--reuse-containers` command line argument pytest-docker-tools **won't** automatically remove containers it has created. It will try to reuse them between pytest invocations. pytest-docker-tools will also keep track of if a container, volume or network has become stale (for example, if you change an image version) and automatically replace it.
+
+**Attention**: When using `--reuse-containers` you must set the `name` attribute on all your pytest-docker-tools fixtures. If you don't use `--reuse-containers` setting the `name` attribute is not required. 
 
 ### Notes on using Reusable Containers
 
-+ Resources created using the `--reuse-containers` argument (containers, networks, volumes) will not have a finalizer, so scopes will may not behave like they normally would
++ Resources created using the `--reuse-containers` argument (containers, networks, volumes) will not have a finalizer, so scopes will may not behave like they normally would. It is up to the test author to make sure there are no collisions where 2 different fixtures share a name.
 + When reusing resources you are responsible to clean them up (e.g. databases, volume data) as data written during tests will not be deleted when they are finished.
-+ Each Resource Container created by Pytest-Docker-Tools will get the following label: `creator: pytest-docker-tools`. When required, this can be used to search for left over 
++ Each Resource Container created by pytest-docker-tools will get the following label: `creator: pytest-docker-tools`. When required, this can be used to search for left over 
   resources. For example containers can be manually cleaned up by executing `docker ps -aq --filter "label=creator=pytest-docker-tools" | xargs docker rm -f`
 
 

--- a/pytest_docker_tools/factories/container.py
+++ b/pytest_docker_tools/factories/container.py
@@ -1,13 +1,12 @@
-import hashlib
-import json
-
 from pytest import UsageError
 
 from pytest_docker_tools.builder import fixture_factory
 from pytest_docker_tools.exceptions import ContainerNotReady, TimeoutError
 from pytest_docker_tools.utils import (
+    hash_params,
     is_reusable_container,
     set_reusable_labels,
+    set_signature,
     wait_for_callable,
 )
 from pytest_docker_tools.wrappers import Container
@@ -22,10 +21,8 @@ def container(request, docker_client, wrapper_class, **kwargs):
     kwargs.update({"detach": True})
     set_reusable_labels(kwargs, request)
 
-    signature = hashlib.sha256(
-        json.dumps(kwargs, sort_keys=True).encode("utf-8")
-    ).hexdigest()
-    kwargs.setdefault("labels", {})["pytest-docker-tools.signature"] = signature
+    signature = hash_params(kwargs)
+    set_signature(kwargs, signature)
 
     if request.config.option.reuse_containers:
         if "name" in kwargs.keys():

--- a/pytest_docker_tools/factories/container.py
+++ b/pytest_docker_tools/factories/container.py
@@ -1,6 +1,5 @@
 from docker.errors import NotFound
 import pytest
-from pytest import UsageError
 
 from pytest_docker_tools.builder import fixture_factory
 from pytest_docker_tools.exceptions import ContainerNotReady, TimeoutError

--- a/pytest_docker_tools/factories/network.py
+++ b/pytest_docker_tools/factories/network.py
@@ -3,7 +3,6 @@ import uuid
 from docker.client import DockerClient
 from docker.errors import NotFound
 import pytest
-from pytest import UsageError
 
 from pytest_docker_tools.builder import fixture_factory
 from pytest_docker_tools.utils import (
@@ -23,7 +22,7 @@ def _remove_stale_network(network):
             continue
 
         if not is_reusable_container(container):
-            raise UsageError(
+            pytest.fail(
                 f"The network {network.name} is connected to a non-reusable container: {container.id}"
             )
 

--- a/pytest_docker_tools/factories/network.py
+++ b/pytest_docker_tools/factories/network.py
@@ -22,7 +22,7 @@ def is_using_network(container, network):
 
 
 def _remove_stale_network(network):
-    for container in network.client.containers.list(ignore_removed=True):
+    for container in network.client.containers.list(ignore_removed=True, all=True):
         if not is_using_network(container, network):
             continue
 

--- a/pytest_docker_tools/factories/network.py
+++ b/pytest_docker_tools/factories/network.py
@@ -75,7 +75,7 @@ def network(request, docker_client: DockerClient, wrapper_class, **kwargs):
             if check_signature(network.attrs["Labels"], signature):
                 return wrapper_class(network)
 
-           # It's ours and it is stale. Clobber it.
+            # It's ours and it is stale. Clobber it.
             _remove_stale_network(network)
 
     name = kwargs.pop("name", "pytest-{uuid}").format(uuid=str(uuid.uuid4()))

--- a/pytest_docker_tools/factories/network.py
+++ b/pytest_docker_tools/factories/network.py
@@ -11,14 +11,10 @@ from pytest_docker_tools.utils import (
     hash_params,
     is_reusable_container,
     is_reusable_network,
+    is_using_network,
     set_reusable_labels,
     set_signature,
 )
-
-
-def is_using_network(container, network):
-    settings = container.attrs.get("NetworkSettings", {})
-    return network.name in settings.get("Networks", {})
 
 
 def _remove_stale_network(network):

--- a/pytest_docker_tools/factories/network.py
+++ b/pytest_docker_tools/factories/network.py
@@ -1,18 +1,44 @@
 import uuid
 
+from docker.client import DockerClient
 from pytest import UsageError
 
 from pytest_docker_tools.builder import fixture_factory
 from pytest_docker_tools.utils import (
     hash_params,
+    is_reusable_container,
     is_reusable_network,
     set_reusable_labels,
     set_signature,
 )
 
 
+def is_using_network(container, network):
+    settings = container.attrs.get("NetworkSettings", {})
+    return network.name in settings.get("Networks", {})
+
+
+def _remove_stale_network(network):
+    for container in network.client.containers.list(ignore_removed=True):
+        if not is_using_network(container, network):
+            continue
+
+        if not is_reusable_container(container):
+            raise UsageError(
+                f"The network {network.name} is connected to a non-reusable container: {container.id}"
+            )
+
+        print(
+            f"Removing container {container.name} connected to stale network {network.name}"
+        )
+        container.remove(force=True)
+
+    print(f"Removing stale reusable network: {network.name}")
+    network.remove()
+
+
 @fixture_factory()
-def network(request, docker_client, wrapper_class, **kwargs):
+def network(request, docker_client: DockerClient, wrapper_class, **kwargs):
     """ Docker network """
 
     set_reusable_labels(kwargs, request)
@@ -35,8 +61,7 @@ def network(request, docker_client, wrapper_class, **kwargs):
                     network.attrs["Labels"].get("pytest-docker-tools.signature", "")
                     != signature
                 ):
-                    print(f"Removing stale reusable network: {name}")
-                    network.remove()
+                    _remove_stale_network(network)
                     break
                 return wrapper_class(network)
         else:

--- a/pytest_docker_tools/factories/network.py
+++ b/pytest_docker_tools/factories/network.py
@@ -1,11 +1,14 @@
-import hashlib
-import json
 import uuid
 
 from pytest import UsageError
 
 from pytest_docker_tools.builder import fixture_factory
-from pytest_docker_tools.utils import is_reusable_network, set_reusable_labels
+from pytest_docker_tools.utils import (
+    hash_params,
+    is_reusable_network,
+    set_reusable_labels,
+    set_signature,
+)
 
 
 @fixture_factory()
@@ -14,10 +17,8 @@ def network(request, docker_client, wrapper_class, **kwargs):
 
     set_reusable_labels(kwargs, request)
 
-    signature = hashlib.sha256(
-        json.dumps(kwargs, sort_keys=True).encode("utf-8")
-    ).hexdigest()
-    kwargs.setdefault("labels", {})["pytest-docker-tools.signature"] = signature
+    signature = hash_params(kwargs)
+    set_signature(kwargs, signature)
 
     wrapper_class = wrapper_class or (lambda network: network)
 

--- a/pytest_docker_tools/factories/volume.py
+++ b/pytest_docker_tools/factories/volume.py
@@ -3,6 +3,7 @@ import os
 import tarfile
 import uuid
 
+import pytest
 from pytest import UsageError
 
 from pytest_docker_tools.builder import fixture_factory
@@ -97,8 +98,8 @@ def volume(request, docker_client, wrapper_class, **kwargs):
                     continue
 
                 if not is_reusable_volume(volume):
-                    raise UsageError(
-                        f"Error: Tried to reuse {volume.name} but it does not appear to be a reusable volume"
+                    pytest.fail(
+                        f"Tried to reuse {volume.name} but it does not appear to be a reusable volume"
                     )
 
                 if (

--- a/pytest_docker_tools/factories/volume.py
+++ b/pytest_docker_tools/factories/volume.py
@@ -95,14 +95,19 @@ def volume(request, docker_client, wrapper_class, **kwargs):
             for volume in volumes:
                 if volume.name != name:
                     continue
+
                 if not is_reusable_volume(volume):
-                    continue
+                    raise UsageError(
+                        f"Error: Tried to reuse {volume.name} but it does not appear to be a reusable volume"
+                    )
+
                 if (
                     volume.attrs["Labels"].get("pytest-docker-tools.signature", "")
                     != signature
                 ):
                     _remove_stale_volume(volume)
                     break
+
                 return wrapper_class(volume)
         else:
             raise UsageError(

--- a/pytest_docker_tools/factories/volume.py
+++ b/pytest_docker_tools/factories/volume.py
@@ -12,18 +12,10 @@ from pytest_docker_tools.utils import (
     hash_params,
     is_reusable_container,
     is_reusable_volume,
+    is_using_volume,
     set_reusable_labels,
     set_signature,
 )
-
-
-def is_using_volume(container, volume):
-    for mount in container.attrs.get("Mounts", []):
-        if mount["Type"] != "volume":
-            continue
-        if mount["Name"] == volume.name:
-            return True
-    return False
 
 
 def _remove_stale_volume(docker_client, volume):

--- a/pytest_docker_tools/utils.py
+++ b/pytest_docker_tools/utils.py
@@ -1,3 +1,6 @@
+import base64
+import hashlib
+import json
 import os
 import sys
 import time
@@ -5,6 +8,7 @@ import time
 from .exceptions import TimeoutError
 
 LABEL_REUSABLE = "pytest-docker-tools.reusable"
+LABEL_SIGNATURE = "pytest-docker-tools.signature"
 
 
 def wait_for_callable(message, callable, timeout=30):
@@ -54,3 +58,21 @@ def set_reusable_labels(kwargs, request):
             LABEL_REUSABLE: str(request.config.option.reuse_containers),
         }
     )
+
+
+class Base64Encoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, bytes):
+            return base64.b64encode(obj).decode("utf-8")
+        return super().default(obj)
+
+
+def hash_params(kwargs):
+    rendered = json.dumps(kwargs, cls=Base64Encoder, sort_keys=True).encode("utf-8")
+    signature = hashlib.sha256(rendered).hexdigest()
+    return signature
+
+
+def set_signature(kwargs, signature):
+    labels = kwargs.setdefault("labels", {})
+    labels[LABEL_SIGNATURE] = signature

--- a/pytest_docker_tools/utils.py
+++ b/pytest_docker_tools/utils.py
@@ -77,3 +77,7 @@ def hash_params(kwargs):
 def set_signature(kwargs, signature):
     labels = kwargs.setdefault("labels", {})
     labels[LABEL_SIGNATURE] = signature
+
+
+def check_signature(labels, signature):
+    return labels.get(LABEL_SIGNATURE, "") == signature

--- a/pytest_docker_tools/utils.py
+++ b/pytest_docker_tools/utils.py
@@ -46,7 +46,8 @@ def is_reusable_network(network):
 
 
 def is_reusable_volume(volume):
-    return volume.attrs["Labels"].get(LABEL_REUSABLE) == "True"
+    labels = volume.attrs["Labels"]
+    return labels and labels.get(LABEL_REUSABLE) == "True"
 
 
 def set_reusable_labels(kwargs, request):

--- a/pytest_docker_tools/utils.py
+++ b/pytest_docker_tools/utils.py
@@ -81,3 +81,17 @@ def set_signature(kwargs, signature):
 
 def check_signature(labels, signature):
     return labels.get(LABEL_SIGNATURE, "") == signature
+
+
+def is_using_network(container, network):
+    settings = container.attrs.get("NetworkSettings", {})
+    return network.name in settings.get("Networks", {})
+
+
+def is_using_volume(container, volume):
+    for mount in container.attrs.get("Mounts", []):
+        if mount["Type"] != "volume":
+            continue
+        if mount["Name"] == volume.name:
+            return True
+    return False

--- a/tests/integration/test_image.py
+++ b/tests/integration/test_image.py
@@ -1,0 +1,27 @@
+from _pytest.pytester import Pytester
+from docker.client import DockerClient
+
+
+def test_image(request, pytester: Pytester, docker_client: DockerClient):
+    pytester.makeconftest(
+        "\n".join(
+            (
+                "from pytest_docker_tools import image",
+                "memcache_image = image(name='memcached:latest')",
+            )
+        )
+    )
+
+    pytester.makepyfile(
+        test_reusable_container="\n".join(
+            (
+                "def test_session_1(memcache_image):",
+                "    assert 'memcached:latest' in memcache_image.tags",
+            )
+        )
+    )
+
+    docker_client.images.pull(repository="memcached:latest")
+
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1, errors=0)

--- a/tests/integration/test_image_or_build.py
+++ b/tests/integration/test_image_or_build.py
@@ -1,10 +1,13 @@
+import os
+from unittest import mock
+
 from _pytest.pytester import Pytester
 from docker.client import DockerClient
-from unittest import mock
-import os
 
 
-def test_image_or_build_env_set(request, pytester: Pytester, docker_client: DockerClient):
+def test_image_or_build_env_set(
+    request, pytester: Pytester, docker_client: DockerClient
+):
     pytester.makeconftest(
         "\n".join(
             (
@@ -31,7 +34,9 @@ def test_image_or_build_env_set(request, pytester: Pytester, docker_client: Dock
     result.assert_outcomes(passed=1, errors=0)
 
 
-def test_image_or_build_env_not_set(request, pytester: Pytester, docker_client: DockerClient):
+def test_image_or_build_env_not_set(
+    request, pytester: Pytester, docker_client: DockerClient
+):
     # A fake build.
     pytester.makefile(
         "",

--- a/tests/integration/test_image_or_build.py
+++ b/tests/integration/test_image_or_build.py
@@ -1,0 +1,67 @@
+from _pytest.pytester import Pytester
+from docker.client import DockerClient
+from unittest import mock
+import os
+
+
+def test_image_or_build_env_set(request, pytester: Pytester, docker_client: DockerClient):
+    pytester.makeconftest(
+        "\n".join(
+            (
+                "from pytest_docker_tools import image_or_build",
+                "memcache_image = image_or_build('ENVIRON_KEY')",
+            )
+        )
+    )
+
+    pytester.makepyfile(
+        test_reusable_container="\n".join(
+            (
+                "def test_session_1(memcache_image):",
+                "    assert 'memcached:latest' in memcache_image.tags",
+            )
+        )
+    )
+
+    docker_client.images.pull(repository="memcached:latest")
+
+    with mock.patch.dict(os.environ, {"ENVIRON_KEY": "memcached:latest"}):
+        result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1, errors=0)
+
+
+def test_image_or_build_env_not_set(request, pytester: Pytester, docker_client: DockerClient):
+    # A fake build.
+    pytester.makefile(
+        "",
+        Dockerfile="\n".join(
+            (
+                "FROM alpine:3.13 AS builder",
+                "LABEL test_image_or_build_env_not_set=yes",
+            )
+        ),
+    )
+
+    pytester.makeconftest(
+        "\n".join(
+            (
+                "from pytest_docker_tools import image_or_build",
+                "memcache_image = image_or_build('ENVIRON_KEY', path='.')",
+            )
+        )
+    )
+
+    pytester.makepyfile(
+        test_reusable_container="\n".join(
+            (
+                "def test_session_1(memcache_image):",
+                "    assert 'test_image_or_build_env_not_set' in memcache_image.labels",
+            )
+        )
+    )
+
+    with mock.patch.dict(os.environ, {}):
+        result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1, errors=0)

--- a/tests/integration/test_network.py
+++ b/tests/integration/test_network.py
@@ -180,6 +180,7 @@ def test_reusable_stale(request, pytester: Pytester, docker_client: DockerClient
     # Running again immediately shouldn't recreate the network
     result = pytester.runpytest("--reuse-containers")
     result.assert_outcomes(passed=1)
+    # This would explode if the network had been removed
     run1.reload()
 
     # Add a label to the network to make it stale

--- a/tests/integration/test_network.py
+++ b/tests/integration/test_network.py
@@ -338,3 +338,78 @@ def test_reusable_stale_dependent_container(
 
     with pytest.raises(NotFound):
         run1.reload()
+
+
+def test_reusable_conflicting_container(
+    request, pytester: Pytester, docker_client: DockerClient
+):
+    def _cleanup():
+        try:
+            container = docker_client.containers.get(
+                "test_reusable_conflicting_container_net"
+            )
+            container.remove(force=True)
+        except NotFound:
+            pass
+
+        try:
+            network = docker_client.networks.get("test_reusable_conflicting_container")
+            network.remove()
+        except NotFound:
+            pass
+
+    request.addfinalizer(_cleanup)
+
+    with pytest.raises(NotFound):
+        docker_client.networks.get("test_reusable_conflicting_container")
+        docker_client.containers.get("test_reusable_conflicting_container_net")
+
+    pytester.makeconftest(
+        "\n".join(
+            (
+                "from pytest_docker_tools import container, fetch, network",
+                "redis_network = network(",
+                "    name='test_reusable_conflicting_container',",
+                ")",
+            )
+        )
+    )
+
+    pytester.makepyfile(
+        test_reusable_network="\n".join(
+            (
+                "def test_session_1(redis_network):",
+                "    assert redis_network.name == 'test_reusable_conflicting_container'",
+            )
+        )
+    )
+
+    result = pytester.runpytest("--reuse-containers")
+    result.assert_outcomes(passed=1)
+
+    # At this stage our network exists and we are going to create a container that
+    # *isn't managed by pytest-docker-tools*
+    # We should refuse to delete that container even when the network is stale
+    docker_client.images.pull(repository="memcached:latest")
+    docker_client.containers.create(
+        name="test_reusable_conflicting_container_net",
+        image="memcached:latest",
+        network="test_reusable_conflicting_container",
+    )
+
+    # Add a label to the network to make the network stale
+    pytester.makeconftest(
+        "\n".join(
+            (
+                "from pytest_docker_tools import container, fetch, network",
+                "redis_network = network(",
+                "    name='test_reusable_conflicting_container',",
+                "    labels={'my-label': 'testtesttest'},",
+                ")",
+            )
+        )
+    )
+
+    result = pytester.runpytest("--reuse-containers")
+    result.assert_outcomes(passed=0, errors=1)
+    result.stdout.re_match_lines([".*is connected to a non-reusable container.*"])

--- a/tests/integration/test_volume.py
+++ b/tests/integration/test_volume.py
@@ -54,6 +54,7 @@ def test_reusable_conflict(request, pytester: Pytester, docker_client: DockerCli
 
     result = pytester.runpytest("--reuse-containers")
     result.assert_outcomes(passed=0, errors=1)
+    result.stdout.re_match_lines([".*does not appear to be a reusable volume"])
 
 
 def test_reusable_must_be_named(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,87 @@
+import pytest
+
+from pytest_docker_tools.utils import check_signature, hash_params, set_signature
+
+
+def test_hash_params():
+    """
+    Test generating signatures for fixture factory kwargs.
+    """
+    assert (
+        hash_params(
+            {
+                "name": "my-name",
+                "labels": {
+                    "label1": "label",
+                },
+            }
+        )
+        == "1c67a2e8dd405725a4cdf7b58fed3e948aed135ac25c494a3b336c83a72ac0c8"
+    )
+
+
+def test_hash_params_raises():
+    """
+    Make sure that we still catch invalid kwargs when generating signature hashes.
+
+    This is really just to get full coverage of the JSONEncoder subclass.
+    We shouldn't hit this exception on the happy path.
+    """
+    with pytest.raises(TypeError):
+        hash_params(
+            {
+                "name": "my-name",
+                "labels": {
+                    "label1": object(),
+                },
+            }
+        )
+
+
+def test_check_signature():
+    signature = "1c67a2e8dd405725a4cdf7b58fed3e948aed135ac25c494a3b336c83a72ac0c8"
+    labels = {
+        "pytest-docker-tools.signature": signature,
+    }
+
+    assert check_signature(labels, signature)
+
+
+def test_set_signature_no_existing_labels():
+    signature = "1c67a2e8dd405725a4cdf7b58fed3e948aed135ac25c494a3b336c83a72ac0c8"
+
+    kwargs = {
+        "name": "hello",
+        "image": "alpine:3.13",
+    }
+    set_signature(kwargs, signature)
+
+    assert kwargs == {
+        "name": "hello",
+        "image": "alpine:3.13",
+        "labels": {
+            "pytest-docker-tools.signature": signature,
+        },
+    }
+
+
+def test_set_signature_preserve_labels():
+    signature = "1c67a2e8dd405725a4cdf7b58fed3e948aed135ac25c494a3b336c83a72ac0c8"
+
+    kwargs = {
+        "name": "hello",
+        "image": "alpine:3.13",
+        "labels": {
+            "mylabel": "hello",
+        },
+    }
+    set_signature(kwargs, signature)
+
+    assert kwargs == {
+        "name": "hello",
+        "image": "alpine:3.13",
+        "labels": {
+            "mylabel": "hello",
+            "pytest-docker-tools.signature": signature,
+        },
+    }


### PR DESCRIPTION
Implementation of https://github.com/Jc2k/pytest-docker-tools/discussions/34

This will automatically replace stale reusable containers. For example:

* Your co-worker has bumped a tag in an image() fixture, for example to use postgres 14 and its new JSON syntax. You git pull and your tests start failing. Sometimes this might not be obvious and the breakage might be some time after the root cause.
* You make a change to some code that triggers a build() fixture. Right now the build() will still run. But the old container will be used.
