### PR TITLE
Allow compatibility with Pytest 7.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -511,7 +511,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "850d91c4a861228c4a140541ebfe74c07f9c67196c03648d331a289bdda59691"
+content-hash = "8530a53641550fe36e520b3abf2c89c1976a5c22d8b214d2f27a53910808d09e"
 
 [metadata.files]
 apipkg = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers=[
 
 [tool.poetry.dependencies]
 python = "^3.6.1"
-pytest = "^6.0.1"
+pytest = ">=6.0.1"
 docker = "^4.3.1"
 
 [tool.poetry.plugins."pytest11"]


### PR DESCRIPTION
Previously when attempting to use Pytest 7:

```
  SolverProblemError

  Because no versions of pytest-docker-tools match >3.1.0,<4.0.0
   and pytest-docker-tools (3.1.0) depends on pytest (>=6.0.1,<7.0.0), pytest-docker-tools (>=3.1.0,<4.0.0) requires pytest (>=6.0.1,<7.0.0).
  So, because shipwell-fastapi-template depends on both pytest (^7.0.0) and pytest-docker-tools (^3.1.0), version solving failed.
```