### PR TITLE
fix: make docstring escape sequence proof

### DIFF
--- a/pytest_docker_tools/builder.py
+++ b/pytest_docker_tools/builder.py
@@ -21,7 +21,7 @@ def build_fixture_function(callable, scope, wrapper_class, kwargs):
     import pytest
 
     def {name}({fixtures_str}):
-        \'\'\'
+        r\'\'\'
         {docstring}
         \'\'\'
         real_kwargs = resolve_fixtures_in_params(request, kwargs)


### PR DESCRIPTION
Matters on Windows, where the path can contain backslashes, i.e.
C:\User\... -> unknown unicode escape sequence.

![image](https://user-images.githubusercontent.com/10866845/172508326-fa8f11f5-482d-48a9-ba10-a3def85119b6.png)


Simply making the docstring in the template a raw string avoids the issue.