### PR TITLE
Switch to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,5 +52,5 @@ combine_as_imports = "true"
 extra_standard_library = "_socket"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
[`poetry-core`](https://github.com/python-poetry/poetry-core) is intended to be a light weight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects.

Using `poetry-core` allows distribution packages to depend only on the build backend.