### PR TITLE
fix: container.ready() race condition, when exposed ports is not available yet

### DIFF
--- a/pytest_docker_tools/wrappers/container.py
+++ b/pytest_docker_tools/wrappers/container.py
@@ -92,6 +92,8 @@ class Container:
         ports = self._container.attrs["NetworkSettings"]["Ports"]
         for port, listeners in ports.items():
             if not listeners:
+                if port in (self._container.attrs["HostConfig"]["PortBindings"] or []):
+                    return False
                 continue
 
             port, proto = port.split("/")


### PR DESCRIPTION
Resolves https://github.com/Jc2k/pytest-docker-tools/issues/42